### PR TITLE
Improve readability by changing word-break behavior

### DIFF
--- a/src/content-style.scss
+++ b/src/content-style.scss
@@ -305,7 +305,7 @@ html[dark] #ytc-filter,
     }
 
     .vc-message {
-      word-break: break-all;
+      word-break: break-word;
       hyphens: auto;
       margin-left: 1rem;
       img {


### PR DESCRIPTION
Currently, this extension handles text-overflow by breaking each character into multiple lines until it eventually fits within the container.
![image](https://user-images.githubusercontent.com/26600816/109433737-8f91e480-7a44-11eb-910c-5eb9189a978c.png)

This PR change that behavior by breaking it into a sequence of "words" instead of just characters, this gives better readability overall because we are trained to recognize each word in a straight line sequence and not a zig-zag pattern where the beginning and the end of a word is very far apart.
![image](https://user-images.githubusercontent.com/26600816/109433743-93be0200-7a44-11eb-9028-1524eec0803a.png)
